### PR TITLE
Add draggable dashboard demo

### DIFF
--- a/frontend/src/dashboard/DashboardPage.tsx
+++ b/frontend/src/dashboard/DashboardPage.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react'
+import { Button, Space } from 'antd'
+import { Grid } from './Grid'
+import { WIDGET_DEFS, WidgetShell } from './widgets'
+import type { LayoutItem, WidgetType } from './types'
+import { randomData } from './mock/data'
+
+const STORAGE_KEY = 'demo-dashboard-layout-v1'
+
+export default function DashboardPage(): JSX.Element {
+    const [items, setItems] = useState<LayoutItem[]>([])
+
+    useEffect(() => {
+        const stored = localStorage.getItem(STORAGE_KEY)
+        if (stored) {
+            setItems(JSON.parse(stored))
+        } else {
+            const initial: LayoutItem[] = [
+                { i: '0', x: 0, y: 0, w: 4, h: 6, type: 'bar' },
+                { i: '1', x: 4, y: 0, w: 4, h: 6, type: 'line' },
+                { i: '2', x: 8, y: 0, w: 4, h: 6, type: 'metric' },
+            ]
+            setItems(initial)
+        }
+    }, [])
+
+    const persist = (next: LayoutItem[]) => {
+        setItems(next)
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+    }
+
+    const onLayoutChange = (layout: LayoutItem[]) => {
+        const next = layout.map((l) => ({ ...l, type: items.find((i) => i.i === l.i)?.type || 'bar' }))
+        persist(next)
+    }
+
+    const addWidget = (type: WidgetType) => {
+        const def = WIDGET_DEFS[type]
+        const id = Date.now().toString()
+        const item: LayoutItem = { i: id, x: 0, y: Infinity, type, ...def.defaultSize }
+        persist([...items, item])
+    }
+
+    const removeWidget = (id: string) => {
+        persist(items.filter((i) => i.i !== id))
+    }
+
+    const cloneWidget = (id: string) => {
+        const source = items.find((i) => i.i === id)
+        if (source) {
+            addWidget(source.type)
+        }
+    }
+
+    return (
+        <div style={{ padding: 16 }}>
+            <Space style={{ marginBottom: 16 }}>
+                {Object.keys(WIDGET_DEFS).map((type) => (
+                    <Button key={type} onClick={() => addWidget(type as WidgetType)}>
+                        Add {WIDGET_DEFS[type as WidgetType].title}
+                    </Button>
+                ))}
+            </Space>
+            <Grid layout={items} onLayoutChange={onLayoutChange}>
+                {items.map((item) => {
+                    const Def = WIDGET_DEFS[item.type]
+                    const Component = Def.component
+                    return (
+                        <div key={item.i} data-grid={item}>
+                            <WidgetShell title={Def.title} onRemove={() => removeWidget(item.i)} onClone={() => cloneWidget(item.i)}>
+                                <Component data={randomData()} />
+                            </WidgetShell>
+                        </div>
+                    )
+                })}
+            </Grid>
+        </div>
+    )
+}

--- a/frontend/src/dashboard/Grid.tsx
+++ b/frontend/src/dashboard/Grid.tsx
@@ -1,0 +1,31 @@
+import { Responsive, WidthProvider, type Layout } from 'react-grid-layout'
+import type { PropsWithChildren } from 'react'
+
+const ResponsiveGridLayout = WidthProvider(Responsive)
+const STORAGE_KEY = 'demo-dashboard-layout-v1'
+
+export interface GridProps extends PropsWithChildren {
+    layout: Layout[]
+    onLayoutChange: (l: Layout[]) => void
+    [key: string]: any
+}
+
+export function Grid({ layout, onLayoutChange, children, ...rest }: GridProps): JSX.Element {
+    const handleLayoutChange = (newLayout: Layout[]) => {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(newLayout))
+        onLayoutChange(newLayout)
+    }
+
+    return (
+        <ResponsiveGridLayout
+            layouts={{ lg: layout }}
+            cols={{ lg: 12, md: 10, sm: 6, xs: 4, xxs: 2 }}
+            rowHeight={30}
+            draggableHandle=".widget-drag-handle"
+            onLayoutChange={handleLayoutChange}
+            {...rest}
+        >
+            {children}
+        </ResponsiveGridLayout>
+    )
+}

--- a/frontend/src/dashboard/index.tsx
+++ b/frontend/src/dashboard/index.tsx
@@ -1,0 +1,3 @@
+import { lazy } from 'react'
+
+export default lazy(() => import('./DashboardPage'))

--- a/frontend/src/dashboard/mock/data.ts
+++ b/frontend/src/dashboard/mock/data.ts
@@ -1,0 +1,3 @@
+export function randomData(length = 10): number[] {
+    return Array.from({ length }, () => Math.round(Math.random() * 100))
+}

--- a/frontend/src/dashboard/types.ts
+++ b/frontend/src/dashboard/types.ts
@@ -1,0 +1,11 @@
+import type { Layout } from 'react-grid-layout'
+
+export type WidgetType = 'bar' | 'line' | 'pie' | 'metric'
+
+export interface LayoutItem extends Layout {
+    type: WidgetType
+}
+
+export interface WidgetProps {
+    data: number[]
+}

--- a/frontend/src/dashboard/widgets/ChartBar.tsx
+++ b/frontend/src/dashboard/widgets/ChartBar.tsx
@@ -1,0 +1,24 @@
+import type { FC } from 'react'
+import type { WidgetProps } from '../types'
+
+export const ChartBar: FC<WidgetProps> = ({ data }) => {
+    const max = Math.max(...data, 1)
+    const barWidth = 100 / data.length
+    return (
+        <svg width="100%" height="100%" viewBox="0 0 100 100" preserveAspectRatio="none">
+            {data.map((value, idx) => {
+                const height = (value / max) * 100
+                return (
+                    <rect
+                        key={idx}
+                        x={idx * barWidth + 2}
+                        y={100 - height}
+                        width={barWidth - 4}
+                        height={height}
+                        fill="#1890ff"
+                    />
+                )
+            })}
+        </svg>
+    )
+}

--- a/frontend/src/dashboard/widgets/ChartLine.tsx
+++ b/frontend/src/dashboard/widgets/ChartLine.tsx
@@ -1,0 +1,20 @@
+import type { FC } from 'react'
+import type { WidgetProps } from '../types'
+
+export const ChartLine: FC<WidgetProps> = ({ data }) => {
+    const max = Math.max(...data, 1)
+    const step = 100 / (data.length - 1)
+    const points = data
+        .map((v, i) => `${i * step},${100 - (v / max) * 100}`)
+        .join(' ')
+    return (
+        <svg width="100%" height="100%" viewBox="0 0 100 100" preserveAspectRatio="none">
+            <polyline
+                fill="none"
+                stroke="#52c41a"
+                strokeWidth="2"
+                points={points}
+            />
+        </svg>
+    )
+}

--- a/frontend/src/dashboard/widgets/ChartPie.tsx
+++ b/frontend/src/dashboard/widgets/ChartPie.tsx
@@ -1,0 +1,31 @@
+import type { FC } from 'react'
+import type { WidgetProps } from '../types'
+
+export const ChartPie: FC<WidgetProps> = ({ data }) => {
+    const total = data.reduce((a, b) => a + b, 0) || 1
+    let cumulative = 0
+    const radius = 50
+    const center = 50
+    const strokeWidth = 20
+
+    const segments = data.map((value) => {
+        const startAngle = (cumulative / total) * 2 * Math.PI
+        cumulative += value
+        const endAngle = (cumulative / total) * 2 * Math.PI
+        const large = endAngle - startAngle > Math.PI ? 1 : 0
+        const x1 = center + radius * Math.cos(startAngle)
+        const y1 = center + radius * Math.sin(startAngle)
+        const x2 = center + radius * Math.cos(endAngle)
+        const y2 = center + radius * Math.sin(endAngle)
+        return `M ${x1} ${y1} A ${radius} ${radius} 0 ${large} 1 ${x2} ${y2} L ${center} ${center}`
+    })
+
+    return (
+        <svg width="100%" height="100%" viewBox="0 0 100 100">
+            {segments.map((d, i) => (
+                <path key={i} d={d} fill="hsl(${(i * 60) % 360},70%,60%)" stroke="#fff" strokeWidth="1" />
+            ))}
+            <circle cx={center} cy={center} r={radius - strokeWidth} fill="#fff" />
+        </svg>
+    )
+}

--- a/frontend/src/dashboard/widgets/Metric.tsx
+++ b/frontend/src/dashboard/widgets/Metric.tsx
@@ -1,0 +1,7 @@
+import { Statistic } from 'antd'
+import type { FC } from 'react'
+import type { WidgetProps } from '../types'
+
+export const Metric: FC<WidgetProps> = ({ data }) => {
+    return <Statistic value={data[0]} style={{ width: '100%', textAlign: 'center' }} />
+}

--- a/frontend/src/dashboard/widgets/WidgetShell.tsx
+++ b/frontend/src/dashboard/widgets/WidgetShell.tsx
@@ -1,0 +1,28 @@
+import { Card, Button, Space } from 'antd'
+import { PropsWithChildren } from 'react'
+import { CloseOutlined, CopyOutlined, ExpandOutlined } from '@ant-design/icons'
+
+export interface WidgetShellProps extends PropsWithChildren {
+    title: string
+    onRemove?: () => void
+    onClone?: () => void
+    onExpand?: () => void
+}
+
+export function WidgetShell({ title, onRemove, onClone, onExpand, children }: WidgetShellProps): JSX.Element {
+    return (
+        <Card
+            title={<span className="widget-drag-handle" style={{ cursor: 'move' }}>{title}</span>}
+            extra={
+                <Space>
+                    {onClone && <Button icon={<CopyOutlined />} size="small" type="text" onClick={onClone} />}
+                    {onExpand && <Button icon={<ExpandOutlined />} size="small" type="text" onClick={onExpand} />}
+                    {onRemove && <Button icon={<CloseOutlined />} size="small" type="text" onClick={onRemove} />}
+                </Space>
+            }
+            size="small"
+        >
+            {children}
+        </Card>
+    )
+}

--- a/frontend/src/dashboard/widgets/index.ts
+++ b/frontend/src/dashboard/widgets/index.ts
@@ -1,0 +1,16 @@
+import type { FC } from 'react'
+import { WidgetShell } from './WidgetShell'
+import { ChartBar } from './ChartBar'
+import { ChartLine } from './ChartLine'
+import { ChartPie } from './ChartPie'
+import { Metric } from './Metric'
+import type { WidgetProps, WidgetType } from '../types'
+
+export const WIDGET_DEFS: Record<WidgetType, { title: string; component: FC<WidgetProps>; defaultSize: { w: number; h: number } }> = {
+    bar: { title: 'Bar Chart', component: ChartBar, defaultSize: { w: 4, h: 6 } },
+    line: { title: 'Line Chart', component: ChartLine, defaultSize: { w: 4, h: 6 } },
+    pie: { title: 'Pie Chart', component: ChartPie, defaultSize: { w: 4, h: 6 } },
+    metric: { title: 'Metric', component: Metric, defaultSize: { w: 2, h: 3 } },
+}
+
+export { WidgetShell }


### PR DESCRIPTION
## Summary
- add a new dashboard page with drag-and-drop grid widgets
- implement simple SVG charts and metric card

## Testing
- `pnpm typescript:check` *(fails: network access blocked)*
- `pnpm lint` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687170891bf8832a954e3d979e6c72b9