### PR TITLE
Add standalone dashboard demo

### DIFF
--- a/frontend/src/dashboard/DashboardPage.tsx
+++ b/frontend/src/dashboard/DashboardPage.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from 'react'
+import { Button, Select } from 'antd'
+import { Grid, loadStoredLayout } from './Grid'
+import { WIDGET_DEFS } from './widgets'
+import { WidgetShell } from './widgets/WidgetShell'
+import { WidgetInstance, WidgetType } from './types'
+import { randomData } from './mock/data'
+import { Layout } from 'react-grid-layout'
+
+let idCounter = 0
+
+export default function DashboardPage(): JSX.Element {
+    const [widgets, setWidgets] = useState<WidgetInstance[]>([])
+
+    useEffect(() => {
+        const stored = loadStoredLayout()
+        if (stored.length) {
+            // reconstruct widgets with default type
+            setWidgets(
+                stored.map((l) => ({
+                    id: String(idCounter++),
+                    type: 'bar',
+                    layout: l,
+                    data: randomData()
+                }))
+            )
+        }
+    }, [])
+
+    const layout: Layout[] = widgets.map((w) => ({ ...w.layout, i: w.id }))
+
+    const onLayoutChange = (l: Layout[]): void => {
+        setWidgets((ws) =>
+            ws.map((w) => {
+                const item = l.find((li) => li.i === w.id)
+                return item ? { ...w, layout: item } : w
+            })
+        )
+    }
+
+    const addWidget = (type: WidgetType): void => {
+        const def = WIDGET_DEFS[type]
+        const layoutItem: Layout = { i: String(idCounter), x: 0, y: Infinity, ...def.defaultSize }
+        const newWidget: WidgetInstance = {
+            id: String(idCounter++),
+            type,
+            layout: layoutItem,
+            data: randomData()
+        }
+        setWidgets((ws) => [...ws, newWidget])
+    }
+
+    const removeWidget = (id: string): void => {
+        setWidgets((ws) => ws.filter((w) => w.id !== id))
+    }
+
+    const cloneWidget = (id: string): void => {
+        const original = widgets.find((w) => w.id === id)
+        if (original) {
+            addWidget(original.type)
+        }
+    }
+
+    return (
+        <div style={{ padding: 16 }}>
+            <div style={{ marginBottom: 16, display: 'flex', gap: 8 }}>
+                <Select<WidgetType> onChange={addWidget} placeholder="Add widget" style={{ width: 160 }}>
+                    {Object.entries(WIDGET_DEFS).map(([type, def]) => (
+                        <Select.Option key={type} value={type as WidgetType}>
+                            {def.title}
+                        </Select.Option>
+                    ))}
+                </Select>
+                <Button onClick={() => setWidgets([])}>Clear</Button>
+            </div>
+            <Grid layout={layout} onLayoutChange={onLayoutChange}>
+                {widgets.map((w) => {
+                    const Def = WIDGET_DEFS[w.type]
+                    return (
+                        <div key={w.id} data-grid={w.layout}>
+                            <WidgetShell
+                                title={Def.title}
+                                onRemove={() => removeWidget(w.id)}
+                                onClone={() => cloneWidget(w.id)}
+                            >
+                                <Def.component data={w.data} />
+                            </WidgetShell>
+                        </div>
+                    )
+                })}
+            </Grid>
+        </div>
+    )
+}

--- a/frontend/src/dashboard/Grid.tsx
+++ b/frontend/src/dashboard/Grid.tsx
@@ -1,0 +1,42 @@
+import { Responsive, WidthProvider, Layout } from 'react-grid-layout'
+import { useEffect } from 'react'
+
+const ResponsiveGridLayout = WidthProvider(Responsive)
+
+import { ReactNode } from 'react'
+
+interface Props {
+    layout: Layout[]
+    onLayoutChange: (l: Layout[]) => void
+    children: ReactNode
+}
+
+const STORAGE_KEY = 'demo-dashboard-layout-v1'
+
+export function Grid({ layout, onLayoutChange, children }: Props): JSX.Element {
+    useEffect(() => {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(layout))
+    }, [layout])
+
+    return (
+        <ResponsiveGridLayout
+            className="layout"
+            layouts={{ lg: layout }}
+            cols={{ lg: 12, md: 10, sm: 6, xs: 4, xxs: 2 }}
+            rowHeight={30}
+            draggableHandle=".widget-drag-handle"
+            onLayoutChange={(_l, all) => onLayoutChange(all)}
+        >
+            {children}
+        </ResponsiveGridLayout>
+    )
+}
+
+export function loadStoredLayout(): Layout[] {
+    try {
+        const value = localStorage.getItem(STORAGE_KEY)
+        return value ? JSON.parse(value) : []
+    } catch {
+        return []
+    }
+}

--- a/frontend/src/dashboard/index.tsx
+++ b/frontend/src/dashboard/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './DashboardPage'

--- a/frontend/src/dashboard/mock/data.ts
+++ b/frontend/src/dashboard/mock/data.ts
@@ -1,0 +1,3 @@
+export function randomData(length = 5, max = 100): number[] {
+    return Array.from({ length }, () => Math.round(Math.random() * max))
+}

--- a/frontend/src/dashboard/package.json
+++ b/frontend/src/dashboard/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "dashboard-demo",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.0",
+    "antd": "^5.0.0",
+    "react-grid-layout": "^1.5.0"
+  },
+  "devDependencies": {
+    "@types/react-grid-layout": "^1.1.2",
+    "vite": "^5.0.0",
+    "typescript": "^5.2.2"
+  }
+}

--- a/frontend/src/dashboard/tsconfig.json
+++ b/frontend/src/dashboard/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": "./",
+    "rootDir": "./",
+    "outDir": "./dist",
+    "jsx": "react-jsx"
+  },
+  "include": ["./**/*"]
+}

--- a/frontend/src/dashboard/types.ts
+++ b/frontend/src/dashboard/types.ts
@@ -1,0 +1,23 @@
+import { Layout } from 'react-grid-layout'
+import { FC } from 'react'
+
+export type WidgetType = 'bar' | 'line' | 'pie' | 'metric'
+
+export interface WidgetProps {
+    data: number[]
+}
+
+export interface WidgetDefinition {
+    title: string
+    component: FC<WidgetProps>
+    defaultSize: { w: number; h: number }
+}
+
+export interface WidgetInstance {
+    id: string
+    type: WidgetType
+    layout: Layout
+    data: number[]
+}
+
+export type LayoutItem = Layout

--- a/frontend/src/dashboard/vite.config.ts
+++ b/frontend/src/dashboard/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import path from 'path'
+
+export default defineConfig({
+    plugins: [react()],
+    css: {
+        preprocessorOptions: {
+            less: {
+                javascriptEnabled: true,
+                additionalData: `@import "${path.resolve(__dirname, 'node_modules/antd/es/style/variable.less')}";`
+            }
+        }
+    },
+    build: {
+        outDir: 'dist'
+    }
+})

--- a/frontend/src/dashboard/widgets/ChartBar.tsx
+++ b/frontend/src/dashboard/widgets/ChartBar.tsx
@@ -1,0 +1,27 @@
+import { WidgetProps } from '../types'
+
+export function ChartBar({ data }: WidgetProps): JSX.Element {
+    const max = Math.max(...data, 1)
+    const width = 200
+    const height = 100
+    const barWidth = width / data.length
+
+    return (
+        <svg width="100%" height={height} viewBox={`0 0 ${width} ${height}`}
+            xmlns="http://www.w3.org/2000/svg">
+            {data.map((d, i) => {
+                const barHeight = (d / max) * height
+                return (
+                    <rect
+                        key={i}
+                        x={i * barWidth + 2}
+                        y={height - barHeight}
+                        width={barWidth - 4}
+                        height={barHeight}
+                        fill="#1677ff"
+                    />
+                )
+            })}
+        </svg>
+    )
+}

--- a/frontend/src/dashboard/widgets/ChartLine.tsx
+++ b/frontend/src/dashboard/widgets/ChartLine.tsx
@@ -1,0 +1,23 @@
+import { WidgetProps } from '../types'
+
+export function ChartLine({ data }: WidgetProps): JSX.Element {
+    const max = Math.max(...data, 1)
+    const width = 200
+    const height = 100
+    const step = width / (data.length - 1)
+    const points = data
+        .map((d, i) => `${i * step},${height - (d / max) * height}`)
+        .join(' ')
+
+    return (
+        <svg width="100%" height={height} viewBox={`0 0 ${width} ${height}`}
+            xmlns="http://www.w3.org/2000/svg">
+            <polyline
+                fill="none"
+                stroke="#52c41a"
+                strokeWidth="2"
+                points={points}
+            />
+        </svg>
+    )
+}

--- a/frontend/src/dashboard/widgets/ChartPie.tsx
+++ b/frontend/src/dashboard/widgets/ChartPie.tsx
@@ -1,0 +1,30 @@
+import { WidgetProps } from '../types'
+
+export function ChartPie({ data }: WidgetProps): JSX.Element {
+    const total = data.reduce((a, b) => a + b, 0)
+    const radius = 40
+    const cx = 50
+    const cy = 50
+    let cumulative = 0
+
+    const segments = data.map((value, idx) => {
+        const startAngle = (cumulative / total) * 2 * Math.PI
+        cumulative += value
+        const endAngle = (cumulative / total) * 2 * Math.PI
+        const largeArc = endAngle - startAngle > Math.PI ? 1 : 0
+        const x1 = cx + radius * Math.cos(startAngle)
+        const y1 = cy + radius * Math.sin(startAngle)
+        const x2 = cx + radius * Math.cos(endAngle)
+        const y2 = cy + radius * Math.sin(endAngle)
+        const path = `M ${cx} ${cy} L ${x1} ${y1} A ${radius} ${radius} 0 ${largeArc} 1 ${x2} ${y2} Z`
+        const color = `hsl(${(idx / data.length) * 360},70%,50%)`
+        return <path key={idx} d={path} fill={color} />
+    })
+
+    return (
+        <svg width="100%" height="100" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+            {segments}
+            <circle cx={cx} cy={cy} r={radius * 0.6} fill="white" />
+        </svg>
+    )
+}

--- a/frontend/src/dashboard/widgets/Metric.tsx
+++ b/frontend/src/dashboard/widgets/Metric.tsx
@@ -1,0 +1,7 @@
+import { Statistic } from 'antd'
+import { WidgetProps } from '../types'
+
+export function Metric({ data }: WidgetProps): JSX.Element {
+    const value = data[0] ?? 0
+    return <Statistic value={value} />
+}

--- a/frontend/src/dashboard/widgets/WidgetShell.tsx
+++ b/frontend/src/dashboard/widgets/WidgetShell.tsx
@@ -1,0 +1,29 @@
+import { Card, Button } from 'antd'
+import { ReactNode } from 'react'
+import { CloseOutlined, CopyOutlined, ArrowsAltOutlined } from '@ant-design/icons'
+
+interface Props {
+    title: string
+    onRemove?: () => void
+    onClone?: () => void
+    onExpand?: () => void
+    children: ReactNode
+}
+
+export function WidgetShell({ title, onRemove, onClone, onExpand, children }: Props): JSX.Element {
+    return (
+        <Card
+            title={<span className="widget-drag-handle" style={{ cursor: 'move' }}>{title}</span>}
+            extra={
+                <div style={{ display: 'flex', gap: 8 }}>
+                    {onClone && <Button size="small" icon={<CopyOutlined />} onClick={onClone} />}
+                    {onExpand && <Button size="small" icon={<ArrowsAltOutlined />} onClick={onExpand} />}
+                    {onRemove && <Button size="small" danger icon={<CloseOutlined />} onClick={onRemove} />}
+                </div>
+            }
+            bodyStyle={{ padding: 8 }}
+        >
+            {children}
+        </Card>
+    )
+}

--- a/frontend/src/dashboard/widgets/index.ts
+++ b/frontend/src/dashboard/widgets/index.ts
@@ -1,0 +1,29 @@
+import { FC } from 'react'
+import { WidgetDefinition, WidgetProps, WidgetType } from '../types'
+import { ChartBar } from './ChartBar'
+import { ChartLine } from './ChartLine'
+import { ChartPie } from './ChartPie'
+import { Metric } from './Metric'
+
+export const WIDGET_DEFS: Record<WidgetType, WidgetDefinition> = {
+    bar: {
+        title: 'Bar Chart',
+        component: ChartBar as FC<WidgetProps>,
+        defaultSize: { w: 4, h: 6 }
+    },
+    line: {
+        title: 'Line Chart',
+        component: ChartLine as FC<WidgetProps>,
+        defaultSize: { w: 4, h: 6 }
+    },
+    pie: {
+        title: 'Pie Chart',
+        component: ChartPie as FC<WidgetProps>,
+        defaultSize: { w: 4, h: 6 }
+    },
+    metric: {
+        title: 'Metric',
+        component: Metric as FC<WidgetProps>,
+        defaultSize: { w: 2, h: 4 }
+    }
+}


### PR DESCRIPTION
## Summary
- add new demo package under `frontend/src/dashboard`
- implement widgets with Ant Design cards and simple SVG charts
- persist and edit layout using `react-grid-layout`
- include Vite configuration with Ant Design Less vars
- correct `@types/react-grid-layout` version in demo package

## Testing
- `pnpm lint` *(fails: Request was cancelled)*
- `pnpm --filter ./frontend/src/dashboard build` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_687173f2594c832abf432cf5cf285162